### PR TITLE
DG2025-16: Add markdown formatting checks and precommit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,10 +1,7 @@
 ---
 name: Custom issue template
 about: Describe this issue template's purpose here.
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
-
-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,8 @@
+# https://lefthook.dev/configuration/
+
+pre-commit:
+  commands:
+    check:
+      glob: "**/*.md"
+      run: npm run format:fix {staged_files}
+      stage_fixed: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "drupal-govcon-2025",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/starlight": "^0.34.3",
-        "astro": "^5.6.1",
-        "sharp": "^0.32.5"
+        "@astrojs/starlight": "0.34.3",
+        "astro": "5.6.1",
+        "sharp": "0.32.5"
+      },
+      "devDependencies": {
+        "prettier": "3.6.2"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -143,13 +146,13 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.2.1.tgz",
-      "integrity": "sha512-SSVM820Jqc6wjsn7qYfV9qfeQvePtVc1nSofhyap7l0/iakUKywj3hfy3UJAOV4sGV4Q/u450RD4AaCaFvNPlg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.2.0.tgz",
+      "integrity": "sha512-wxhSKRfKugLwLlr4OFfcqovk+LIFtKwLyGPqMsv+9/ibqqnW3Gv7tBhtKEb0gAyUAC4G9BTVQeQahqnQAhd6IQ==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.1.0",
+        "debug": "^4.3.7",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "is-docker": "^3.0.0",
@@ -213,17 +216,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@capsizecss/unpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-2.4.0.tgz",
-      "integrity": "sha512-GrSU71meACqcmIUxPYOJvGKF0yryjN/L1aCuE9DViCTJI7bfkjgYDPD1zbNDcINJwSSP6UaBZY9GAbYDO7re0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "blob-to-buffer": "^1.2.8",
-        "cross-fetch": "^3.0.4",
-        "fontkit": "^2.0.2"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -1525,15 +1517,6 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1556,15 +1539,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/fontkit": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.8.tgz",
-      "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/hast": {
@@ -1803,16 +1777,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.7.13",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.7.13.tgz",
-      "integrity": "sha512-cRGq2llKOhV3XMcYwQpfBIUcssN6HEK5CRbcMxAfd9OcFhvWE7KUy50zLioAZVVl3AqgUTJoNTlmZfD2eG0G1w==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.6.1.tgz",
+      "integrity": "sha512-aQ2TV7wIf+q2Oi6gGWMINHWEAZqoP0eH6/mihodfTJYATPWyd03JIGVfjtYUJlkNdNSKxDXwEe/r/Zx4CZ1FPg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.11.0",
         "@astrojs/internal-helpers": "0.6.1",
         "@astrojs/markdown-remark": "6.3.1",
-        "@astrojs/telemetry": "3.2.1",
-        "@capsizecss/unpack": "^2.4.0",
+        "@astrojs/telemetry": "3.2.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.1.4",
         "acorn": "^8.14.1",
@@ -1834,7 +1807,6 @@
         "esbuild": "^0.25.0",
         "estree-walker": "^3.0.3",
         "flattie": "^1.1.1",
-        "fontace": "~0.3.0",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.1.1",
@@ -1856,11 +1828,10 @@
         "tinyglobby": "^0.2.12",
         "tsconfck": "^3.1.5",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.5.0",
         "unist-util-visit": "^5.0.0",
         "unstorage": "^1.15.0",
         "vfile": "^6.0.3",
-        "vite": "^6.3.4",
+        "vite": "^6.2.4",
         "vitefu": "^1.0.6",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^21.1.1",
@@ -2096,26 +2067,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/blob-to-buffer": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz",
-      "integrity": "sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2142,15 +2093,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/brotli": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.1.2"
       }
     },
     "node_modules/buffer": {
@@ -2299,15 +2241,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2399,15 +2332,6 @@
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/crossws": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
@@ -2432,19 +2356,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2572,12 +2483,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/dfa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -2857,12 +2762,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -2890,33 +2789,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/fontace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.3.0.tgz",
-      "integrity": "sha512-czoqATrcnxgWb/nAkfyIrRp6Q8biYj7nGnL6zfhTcX+JKKpWHFBnb8uNMw/kZr7u++3Y3wYSYoZgHkCcsuBpBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/fontkit": "^2.0.8",
-        "fontkit": "^2.0.4"
-      }
-    },
-    "node_modules/fontkit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
-      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@swc/helpers": "^0.5.12",
-        "brotli": "^1.3.2",
-        "clone": "^2.1.2",
-        "dfa": "^1.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "restructure": "^3.0.0",
-        "tiny-inflate": "^1.0.3",
-        "unicode-properties": "^1.4.0",
-        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/fs-constants": {
@@ -3997,12 +3869,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "license": "CC0-1.0"
-    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -4845,26 +4711,6 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
@@ -4908,12 +4754,6 @@
         "node-fetch-native": "^1.6.4",
         "ufo": "^1.5.4"
       }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -5005,12 +4845,6 @@
         "@pagefind/linux-x64": "1.3.0",
         "@pagefind/windows-x64": "1.3.0"
       }
-    },
-    "node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "license": "MIT"
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -5203,6 +5037,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -5602,12 +5452,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/restructure": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
-      "license": "MIT"
-    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -5747,9 +5591,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "version": "0.32.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.5.tgz",
+      "integrity": "sha512-0dap3iysgDkNaPOaOL4X/0akdu0ma62GcdC2NBQ+93eqpePdDdr2/LM0sFdDSMmN7yS+odyZtPsb7tx/cYBKnQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6045,12 +5889,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "license": "MIT"
-    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -6072,12 +5910,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -6123,7 +5955,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -6187,26 +6020,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
-    "node_modules/unicode-properties": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/unicode-trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      }
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -6224,16 +6037,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unifont": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.5.0.tgz",
-      "integrity": "sha512-4DueXMP5Hy4n607sh+vJ+rajoLu778aU3GzqeTCqsD/EaUcvqZT9wPC8kgK6Vjh22ZskrxyRCR71FwNOaYn6jA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0",
-        "ohash": "^2.0.0"
       }
     },
     "node_modules/unist-util-find-after": {
@@ -6612,22 +6415,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which-pm-runs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "sharp": "0.32.5"
       },
       "devDependencies": {
+        "lefthook": "1.11.14",
         "prettier": "3.6.2"
       }
     },
@@ -3487,6 +3488,169 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.11.14.tgz",
+      "integrity": "sha512-Dv91Lnu/0jLT5pCZE0IkEfrpTXUhyX9WG4upEMPkKPCl5aBgJdoqVw/hbh8drcVrC6y7k1PqsRmWSERmO57weQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.11.14",
+        "lefthook-darwin-x64": "1.11.14",
+        "lefthook-freebsd-arm64": "1.11.14",
+        "lefthook-freebsd-x64": "1.11.14",
+        "lefthook-linux-arm64": "1.11.14",
+        "lefthook-linux-x64": "1.11.14",
+        "lefthook-openbsd-arm64": "1.11.14",
+        "lefthook-openbsd-x64": "1.11.14",
+        "lefthook-windows-arm64": "1.11.14",
+        "lefthook-windows-x64": "1.11.14"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.11.14.tgz",
+      "integrity": "sha512-YPbUK6kGytY5W6aNUrzK7Vod3ynLVvj5JQiBh0DjlxCHMgIQPpFkDfwQzGw1E8CySyC95HXO83En5Ule8umS7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.11.14.tgz",
+      "integrity": "sha512-l9RhSBp1SHqLCjSGWoeeVWqKcTBOMW8v2CCYrUt5eb6sik7AjT6+Neqf3sClsXH7SjELjj43yjmg6loqPtfDgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.11.14.tgz",
+      "integrity": "sha512-oSdJKGGMohktFXC6faZCUt5afyHpDwWGIWAkHGgOXUVD/LiZDEn6U/8cQmKm1UAfBySuPTtfir0VeM04y6188g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.11.14.tgz",
+      "integrity": "sha512-gZdMWZwOtIhIPK3GPYac7JhXrxF188gkw65i6O7CedS/meDlK2vjBv5BUVLeD/satv4+jibEdV0h4Qqu/xIh2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.11.14.tgz",
+      "integrity": "sha512-sZmqbTsGQFQw7gbfi9eIHFOxfcs66QfZYLRMh1DktODhyhRXB8RtI6KMeKCtPEGLhbK55/I4TprC8Qvj86UBgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.11.14.tgz",
+      "integrity": "sha512-c+to1BRzFe419SNXAR6YpCBP8EVWxvUxlON3Z+efzmrHhdlhm7LvEoJcN4RQE4Gc2rJQJNe87OjsEZQkc4uQLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.11.14.tgz",
+      "integrity": "sha512-fivG3D9G4ASRCTf3ecfz1WdnrHCW9pezaI8v1NVve8t6B2q0d0yeaje5dfhoAsAvwiFPRaMzka1Qaoyu8O8G9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.11.14.tgz",
+      "integrity": "sha512-vikmG0jf7JVKR3be6Wk3l1jtEdedEqk1BTdsaHFX1bj0qk0azcqlZ819Wt/IoyIYDzQCHKowZ6DuXsRjT+RXWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.11.14.tgz",
+      "integrity": "sha512-5PoAJ9QKaqxJn1NWrhrhXpAROpl/dT7bGTo7VMj2ATO1cpRatbn6p+ssvc3tgeriFThowFb1D11Fg6OlFLi6UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.11.14",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.11.14.tgz",
+      "integrity": "sha512-kBeOPR0Aj5hQGxoBBntgz5/e/xaH5Vnzlq9lJjHW8sf23qu/JVUGg6ceCoicyVWJi+ZOBliTa8KzwCu+mgyJjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
+    "format:check": "npx prettier ./**/*.md --check",
+    "format:fix": "npx prettier ./**/*.md --write",
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.34.3",
-    "astro": "^5.6.1",
-    "sharp": "^0.32.5"
+    "@astrojs/starlight": "0.34.3",
+    "astro": "5.6.1",
+    "sharp": "0.32.5"
+  },
+  "devDependencies": {
+    "prettier": "3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sharp": "0.32.5"
   },
   "devDependencies": {
+    "lefthook": "1.11.14",
     "prettier": "3.6.2"
   }
 }

--- a/src/content/docs/guides/01-intro.md
+++ b/src/content/docs/guides/01-intro.md
@@ -10,6 +10,7 @@ Design systems help teams focus on important problems specific to their team and
 ## What a design system is
 
 Design systems come in different shapes and sizes, but they all essentially contain the following:
+
 - **Principles**. The "why" in this entire effort. It's your north star for your roadmap and all future decisions.
 - **Guidance**. What it is and when/how to use the design system.
 - **Tokens, Components, and Patterns**. Something you can use to build _some thing_.
@@ -22,14 +23,13 @@ You can grow your design system organically and start where your strengths lie, 
 
 - **A collection of colors and fonts.** That's a styleguide and while it is important for maintaining consistency, it serves as more of a theming layer.
 - **A design file.** This can be a good starting point, but a design system is a sum of parts. It's the same issue as if you only shipped code. No one outside of devs would be able to see or use it.
-- **Component libraries**.  While useful and ensure some form of consistency, there's no guidance on when or when _not_ to use components.
+- **Component libraries**. While useful and ensure some form of consistency, there's no guidance on when or when _not_ to use components.
 
 ## Systems-level thinking
 
 Since a design system is a collection of parts, to be successful you'll need systems-level thinking. This means that with your work you'll have to think about how all of the pieces are connected.
 
 TK
-
 
 ## Aligning goals
 

--- a/src/content/docs/guides/05-creating-components.md
+++ b/src/content/docs/guides/05-creating-components.md
@@ -6,7 +6,6 @@ description: The work involved in creating a component.
 1. Research
 1. Prototyping
 1. Development
-  1. API
-  1. Customizations
+   1. API
+   1. Customizations
 1. Guidance
-1.


### PR DESCRIPTION
This work improves security and code quality by pinning NPM dependencies and checking markdown formatting. As well as fixes formatting issues on staged files.

Closes #16.

## Dependency updates

New dev dependencies.

| Dependency name              | Previous version | New version |
| :---------------------------- | :--------------: | :---------: |
| lefthook     |        --        |   1.11.14   |
| prettier |     --     |     3.6.2     |